### PR TITLE
Add Postgres env config

### DIFF
--- a/src/main/java/com/api/mvc/config/PostgresConfig.java
+++ b/src/main/java/com/api/mvc/config/PostgresConfig.java
@@ -1,0 +1,38 @@
+package com.api.mvc.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class PostgresConfig {
+
+    @Value("${DB_HOST:localhost}")
+    private String host;
+
+    @Value("${DB_PORT:5432}")
+    private String port;
+
+    @Value("${DB_NAME:meubanco}")
+    private String database;
+
+    @Value("${DB_USERNAME:admin}")
+    private String username;
+
+    @Value("${DB_PASSWORD:admin123}")
+    private String password;
+
+    @Bean
+    public DataSource dataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        String url = String.format("jdbc:postgresql://%s:%s/%s", host, port, database);
+        dataSource.setUrl(url);
+        dataSource.setUsername(username);
+        dataSource.setPassword(password);
+        return dataSource;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,4 @@
-# Conexão com o Postgres local
-spring.datasource.url=jdbc:postgresql://localhost:5432/meubanco
-spring.datasource.username=admin
-spring.datasource.password=admin123
-spring.datasource.driver-class-name=org.postgresql.Driver
-
-# JPA
+# Configuracao do JPA
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
## Summary
- add PostgresConfig for datasource using environment variables
- remove hardcoded datasource info from `application.properties`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68459ae31e348333bf30cee3ec3638cc